### PR TITLE
fix threshold handling in wake_up_mode_set() and wake_up_mode_get()

### DIFF
--- a/lis2du12_reg.c
+++ b/lis2du12_reg.c
@@ -1310,12 +1310,12 @@ int32_t lis2du12_wake_up_mode_set(const stmdev_ctx_t *ctx, lis2du12_wkup_md_t *v
 
   if (val->threshold > 63U)
   {
-    interrupt_cfg.wake_ths_w = PROPERTY_ENABLE;
+    interrupt_cfg.wake_ths_w = PROPERTY_DISABLE;
     wake_up_ths.wk_ths = val->threshold / 4U;
   }
   else
   {
-    interrupt_cfg.wake_ths_w = PROPERTY_DISABLE;
+    interrupt_cfg.wake_ths_w = PROPERTY_ENABLE;
     wake_up_ths.wk_ths = val->threshold;
   }
 
@@ -1379,7 +1379,7 @@ int32_t lis2du12_wake_up_mode_get(const stmdev_ctx_t *ctx, lis2du12_wkup_md_t *v
   val->y_en = ctrl1.wu_y_en;
   val->x_en = ctrl1.wu_x_en;
 
-  if (interrupt_cfg.wake_ths_w == PROPERTY_ENABLE)
+  if (interrupt_cfg.wake_ths_w == PROPERTY_DISABLE)
   {
     val->threshold = wake_up_ths.wk_ths * 4U;
   }

--- a/lis2du12_reg.h
+++ b/lis2du12_reg.h
@@ -992,7 +992,7 @@ typedef struct
   uint8_t x_en  : 1; /* Detection on X-axis */
   uint8_t y_en  : 1; /* Detection on Y-axis */
   uint8_t z_en  : 1; /* Detection on Z-axis */
-  uint8_t threshold; /* full scale dependent */
+  uint8_t threshold; /* 1 LSB = FS_XL / 2^8 */
   uint8_t duration;  /* 1 LSb: 1 ODR_time */
   struct
   {


### PR DESCRIPTION
The issue https://github.com/STMicroelectronics/lis2du12-pid/issues/1 already states that handling of threshold in wake_up_mode_set() is incorrect. The same applies to wake_up_mode_get().

According to the Datasheet of the LIS2DU12 for WAKE_THS_W:

> Weight of 1 LSB of wake-up threshold. Default value: 0
> (0: 1 LSB = FS_XL / (2^6);
> 1: 1 LSB = FS_XL / (2^8) )

This means, that if the WAKE_THS_W is enabled the weight is FS/2^8 which means it must not be modified/scaled. If WAKE_THS_W is disabled the weight is FS/2^6 and has to be scaled accordingly.